### PR TITLE
修复getClickWordsPosition()里的一个问题

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -9,7 +9,7 @@
  * @returns
  */
 export function getClickWordsPosition(pElement, x, y, separators = ['']) {
-  if (!pElement || (pElement && pElement.childNodes)) return null
+  if (!pElement || !pElement.childNodes) return null
   let lineHeight = Number(window.getComputedStyle(pElement).lineHeight.replace('px', ''))
   for (let i = 0; i < pElement.childNodes.length; i++) {
     const node = pElement.childNodes[i]

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -9,7 +9,7 @@
  * @returns
  */
 export function getClickWordsPosition(pElement, x, y, separators = ['']) {
-  if (!pElement || (!pElement && pElement.childNodes)) return null
+  if (!pElement || (pElement && pElement.childNodes)) return null
   let lineHeight = Number(window.getComputedStyle(pElement).lineHeight.replace('px', ''))
   for (let i = 0; i < pElement.childNodes.length; i++) {
     const node = pElement.childNodes[i]


### PR DESCRIPTION

```
export function getClickWordsPosition(pElement, x, y, separators = ['']) {
  if (!pElement || (!pElement && pElement.childNodes)) return null
  ...
}
```

pElement是空或者不空，pElement.childNodes 都不会执行