### PR TITLE
修复禁用划线后 长按依然可划线问题

### DIFF
--- a/src/base_easy_marker.js
+++ b/src/base_easy_marker.js
@@ -372,13 +372,13 @@ class EasyMarker {
         EventType.TOUCH_END,
         this.handleTouchEnd.bind(this),
       )
+      this.touchEvent.registerEvent(
+        EventType.LONG_TAP,
+        this.handleLongTap.bind(this),
+      )
     }
 
     this.touchEvent.registerEvent(EventType.TAP, this.handleTap.bind(this))
-    this.touchEvent.registerEvent(
-      EventType.LONG_TAP,
-      this.handleLongTap.bind(this),
-    )
 
     const CursorElement =
       this.options.cursor && this.options.cursor.Cursor


### PR DESCRIPTION
1. 修复禁用划线后 长按依然可划线问题