### PR TITLE
修复PC上无法选中第一个字问题，PC禁用cursor拖动

### DIFF
--- a/src/element/cursor.js
+++ b/src/element/cursor.js
@@ -155,6 +155,9 @@ export default class Cursor extends BaseElement {
    * @memberof Cursor
    */
   inRegion(position = {}) {
+    if (this.deviceType === DeviceType.PC) {
+      return { inRegion: false }
+    }
     const maxDistance = this.height
     let distance = Number.MAX_SAFE_INTEGER
     if (position.y > this.position.y && position.y < this.position.y + this.height) {

--- a/src/node_easy_marker.js
+++ b/src/node_easy_marker.js
@@ -214,7 +214,7 @@ class NodeEasyMarker extends BaseEasyMarker {
           element,
           x,
           y,
-          this.movingCursor === this.cursor.start,
+          this.movingCursor !== this.cursor.start,
         )
         if (clickPosition) {
           this.textNode.start = new TextNode(


### PR DESCRIPTION
1. 修复PC上无法选中第一个字问题
2. PC禁用cursor拖动