### PR TITLE
修复跨>=3行选择时mask右侧覆盖不全问题

### DIFF
--- a/src/lib/text_node.js
+++ b/src/lib/text_node.js
@@ -97,6 +97,8 @@ export default class TextNode {
             ? lastLineMergedRect.top : rect.top
           lastLineMergedRect.bottom = lastLineMergedRect.bottom - rect.bottom > 0
             ? lastLineMergedRect.bottom : rect.bottom
+          lastLineMergedRect.right = lastLineMergedRect.right - rect.right > 0
+            ? lastLineMergedRect.right : rect.right
         } else {
           lineMergedRects.push(copyRect(rect))
         }


### PR DESCRIPTION
![lADPJv8gSjPZ19DNCWDNBGg_1128_2400 jpg_720x720g](https://user-images.githubusercontent.com/46518553/159026007-612bf0d2-14d1-469d-9128-c690d696cf44.jpg)
